### PR TITLE
Add missing CEconEntity::InitializeAttributes() call

### DIFF
--- a/game/shared/cstrike15/weapon_csbase.cpp
+++ b/game/shared/cstrike15/weapon_csbase.cpp
@@ -3065,6 +3065,7 @@ void CWeaponCSBase::Spawn()
 {
 	m_nWeaponID = WeaponIdFromString( GetClassname() );
 
+	BaseClass::InitializeAttributes();
 	BaseClass::Spawn();
 
 	// Override the bloat that our base class sets as it's a little bit bigger than we want.


### PR DESCRIPTION
`CEconEntity::InitializeAttributes()` call is used in `CWeaponCSBase::Spawn` and `CEconWearable::Spawn` (gloves, missing in the current cstrike repo).