### PR TITLE
thirdparty: added e2k support (MCST Elbrus 2000)

### DIFF
--- a/thirdparty/protobuf-2.5.0/cmake/CMakeLists.txt
+++ b/thirdparty/protobuf-2.5.0/cmake/CMakeLists.txt
@@ -5,7 +5,12 @@ cmake_minimum_required(VERSION 2.8.12)
 if(UNIX AND NOT APPLE)
   #Downgrade ABI for kisakstrike
   message(STATUS "Downgrading CXX11 ABI for kisakstrike!")
-  add_definitions(-D_GLIBCXX_USE_CXX11_ABI=0 -O2 -march=native)
+  if(CMAKE_SYSTEM_PROCESSOR STREQUAL "e2k")
+    # O3 on mcst-lcc approximately equal to O2 at gcc X86/ARM
+    add_definitions(-D_GLIBCXX_USE_CXX11_ABI=0 -O3 -march=native)
+  else()
+    add_definitions(-D_GLIBCXX_USE_CXX11_ABI=0 -O2 -march=native)
+  endif()
 endif()
 
 

--- a/thirdparty/protobuf-2.5.0/src/google/protobuf/stubs/atomicops.h
+++ b/thirdparty/protobuf-2.5.0/src/google/protobuf/stubs/atomicops.h
@@ -184,6 +184,8 @@ GOOGLE_PROTOBUF_ATOMICOPS_ERROR
 #include <google/protobuf/stubs/atomicops_internals_mips_gcc.h>
 #elif defined(__pnacl__)
 #include <google/protobuf/stubs/atomicops_internals_pnacl.h>
+#elif defined(GOOGLE_PROTOBUF_ARCH_E2K)
+#include <google/protobuf/stubs/atomicops_internals_e2k_lcc.h>
 #else
 GOOGLE_PROTOBUF_ATOMICOPS_ERROR
 #endif

--- a/thirdparty/protobuf-2.5.0/src/google/protobuf/stubs/atomicops_internals_e2k_lcc.h
+++ b/thirdparty/protobuf-2.5.0/src/google/protobuf/stubs/atomicops_internals_e2k_lcc.h
@@ -1,0 +1,163 @@
+// Protocol Buffers - Google's data interchange format
+// Copyright 2012 Google Inc.  All rights reserved.
+// http://code.google.com/p/protobuf/
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//     * Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above
+// copyright notice, this list of conditions and the following disclaimer
+// in the documentation and/or other materials provided with the
+// distribution.
+//     * Neither the name of Google Inc. nor the names of its
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+// This file is an internal atomic implementation, use atomicops.h instead.
+//
+// LinuxKernelCmpxchg and Barrier_AtomicIncrement are from Google Gears.
+
+#ifndef GOOGLE_PROTOBUF_ATOMICOPS_INTERNALS_E2K_LCC_H_
+#define GOOGLE_PROTOBUF_ATOMICOPS_INTERNALS_E2K_LCC_H_
+
+namespace google {
+namespace protobuf {
+namespace internal {
+
+inline Atomic32 NoBarrier_CompareAndSwap(volatile Atomic32* ptr,
+                                         Atomic32 old_value,
+                                         Atomic32 new_value) {
+  __atomic_compare_exchange_n(ptr, &old_value, new_value, false,
+                              __ATOMIC_RELAXED, __ATOMIC_RELAXED);
+  return old_value;
+}
+
+inline Atomic32 NoBarrier_AtomicExchange(volatile Atomic32* ptr,
+                                         Atomic32 new_value) {
+  return __atomic_exchange_n(ptr, new_value, __ATOMIC_RELAXED);
+}
+
+inline Atomic32 NoBarrier_AtomicIncrement(volatile Atomic32* ptr,
+                                          Atomic32 increment) {
+  return __atomic_add_fetch(ptr, increment, __ATOMIC_RELAXED);
+}
+
+inline Atomic32 Barrier_AtomicIncrement(volatile Atomic32* ptr,
+                                        Atomic32 increment) {
+  return __atomic_add_fetch(ptr, increment, __ATOMIC_SEQ_CST);
+}
+
+inline Atomic32 Acquire_CompareAndSwap(volatile Atomic32* ptr,
+                                       Atomic32 old_value,
+                                       Atomic32 new_value) {
+  __atomic_compare_exchange_n(ptr, &old_value, new_value, false,
+                              __ATOMIC_RELEASE, __ATOMIC_ACQUIRE);
+  return old_value;
+}
+
+inline Atomic32 Release_CompareAndSwap(volatile Atomic32* ptr,
+                                       Atomic32 old_value,
+                                       Atomic32 new_value) {
+  __atomic_compare_exchange_n(ptr, &old_value, new_value, false,
+                              __ATOMIC_RELEASE, __ATOMIC_ACQUIRE);
+  return old_value;
+}
+
+inline void NoBarrier_Store(volatile Atomic32* ptr, Atomic32 value) {
+  __atomic_store_n(ptr, value, __ATOMIC_RELAXED);
+}
+
+inline void MemoryBarrier() {
+  __sync_synchronize();
+}
+
+inline void Acquire_Store(volatile Atomic32* ptr, Atomic32 value) {
+  __atomic_store_n(ptr, value, __ATOMIC_SEQ_CST);
+}
+
+inline void Release_Store(volatile Atomic32* ptr, Atomic32 value) {
+  __atomic_store_n(ptr, value, __ATOMIC_RELEASE);
+}
+
+inline Atomic32 NoBarrier_Load(volatile const Atomic32* ptr) {
+  return __atomic_load_n(ptr, __ATOMIC_RELAXED);
+}
+
+inline Atomic32 Acquire_Load(volatile const Atomic32* ptr) {
+  return __atomic_load_n(ptr, __ATOMIC_ACQUIRE);
+}
+
+inline Atomic32 Release_Load(volatile const Atomic32* ptr) {
+  return __atomic_load_n(ptr, __ATOMIC_SEQ_CST);
+}
+
+inline void Release_Store(volatile Atomic64* ptr, Atomic64 value) {
+  __atomic_store_n(ptr, value, __ATOMIC_RELEASE);
+}
+
+inline Atomic64 Acquire_Load(volatile const Atomic64* ptr) {
+  return __atomic_load_n(ptr, __ATOMIC_ACQUIRE);
+}
+
+inline Atomic64 Acquire_CompareAndSwap(volatile Atomic64* ptr,
+                                       Atomic64 old_value,
+                                       Atomic64 new_value) {
+  __atomic_compare_exchange_n(ptr, &old_value, new_value, false,
+                              __ATOMIC_ACQUIRE, __ATOMIC_ACQUIRE);
+  return old_value;
+}
+
+inline Atomic64 NoBarrier_CompareAndSwap(volatile Atomic64* ptr,
+                                         Atomic64 old_value,
+                                         Atomic64 new_value) {
+  __atomic_compare_exchange_n(ptr, &old_value, new_value, false,
+                              __ATOMIC_RELAXED, __ATOMIC_RELAXED);
+  return old_value;
+}
+
+inline Atomic64 NoBarrier_AtomicIncrement(volatile Atomic64* ptr,
+                                          Atomic64 increment) {
+  return __atomic_add_fetch(ptr, increment, __ATOMIC_RELAXED);
+}
+
+inline void NoBarrier_Store(volatile Atomic64* ptr, Atomic64 value) {
+  __atomic_store_n(ptr, value, __ATOMIC_RELAXED);
+}
+
+inline Atomic64 NoBarrier_AtomicExchange(volatile Atomic64* ptr,
+                                         Atomic64 new_value) {
+  return __atomic_exchange_n(ptr, new_value, __ATOMIC_RELAXED);
+}
+
+inline Atomic64 NoBarrier_Load(volatile const Atomic64* ptr) {
+  return __atomic_load_n(ptr, __ATOMIC_RELAXED);
+}
+
+inline Atomic64 Release_CompareAndSwap(volatile Atomic64* ptr,
+                                       Atomic64 old_value,
+                                       Atomic64 new_value) {
+  __atomic_compare_exchange_n(ptr, &old_value, new_value, false,
+                              __ATOMIC_RELEASE, __ATOMIC_ACQUIRE);
+  return old_value;
+}
+
+}  // namespace internal
+}  // namespace protobuf
+}  // namespace google
+
+#endif  // GOOGLE_PROTOBUF_ATOMICOPS_INTERNALS_E2K_LCC_H_

--- a/thirdparty/protobuf-2.5.0/src/google/protobuf/stubs/platform_macros.h
+++ b/thirdparty/protobuf-2.5.0/src/google/protobuf/stubs/platform_macros.h
@@ -57,6 +57,9 @@
 #elif defined(__ppc__)
 #define GOOGLE_PROTOBUF_ARCH_PPC 1
 #define GOOGLE_PROTOBUF_ARCH_32_BIT 1
+#elif defined(__e2k__)
+#define GOOGLE_PROTOBUF_ARCH_E2K 1
+#define GOOGLE_PROTOBUF_ARCH_64_BIT 1
 #else
 #error Host architecture was not detected as supported by protobuf
 #endif

--- a/thirdparty/protobuf-2.5.0/src/google/protobuf/stubs/strutil.cc
+++ b/thirdparty/protobuf-2.5.0/src/google/protobuf/stubs/strutil.cc
@@ -355,9 +355,10 @@ int UnescapeCEscapeSequences(const char* source, char* dest,
           const char *hex_start = p;
           while (isxdigit(p[1]))  // arbitrarily many hex digits
             ch = (ch << 4) + hex_digit_to_int(*++p);
-          if (ch > 0xFF)
-            LOG_STRING(ERROR, errors) << "Value of " <<
-              "\\" << string(hex_start, p+1-hex_start) << " exceeds 8 bits";
+          if (ch > 0xFF) {
+            string strt = string(hex_start, p+1-hex_start);
+            LOG_STRING(ERROR, errors) << "Value of " << "\\" << strt.c_str() << " exceeds 8 bits";
+          }
           *d++ = ch;
           break;
         }

--- a/thirdparty/telemetry/include/radtypes.h
+++ b/thirdparty/telemetry/include/radtypes.h
@@ -35,7 +35,7 @@
 //  __RADPPC__ means powerpc
 //  __RADX86__ means x86 or x64
 //  __RADX64__ means x64
-//  __RADX64__ means x64
+//  __RADE2K__ means e2k (MCST Elbrus 2000)
 
 // __RADNOVARARGMACROS__ means #defines can't use ...
 
@@ -205,12 +205,20 @@
   #define __RADDETECTEDPROC__ __RADCELLSPU__
   #define __RADBIGENDIAN__
 #endif
+#if defined(__e2k__)
+  #define __RADE2K__ 6
+  #if defined(__MMX__)
+    #define __RADMMX__
+  #endif
+  #define __RADDETECTEDPROC__ __RADE2K__
+  #define __RADLITTLEENDIAN__
+#endif
 
 #if !defined(__RADDETECTEDPROC__)
   #error "radtypes.h did not detect your processor type."
 #endif
 
-#if defined(__ppc64__) || defined(__aarch64__) || defined(_M_X64) || defined(__x86_64__) || defined(__x86_64)
+#if defined(__ppc64__) || defined(__aarch64__) || defined(_M_X64) || defined(__x86_64__) || defined(__x86_64) || defined(__e2k__)
   #define __RAD64__
   #define __RAD64REGS__  // need to set this for platforms that aren't 64-bit, but have 64-bit regs (xenon, ps3)
 #endif


### PR DESCRIPTION
Added e2k support in telemetry and protobuf-2.5.0.