### PR TITLE
external/crypto++-5.61: added e2k support (MCST Elbrus 2000)

### DIFF
--- a/external/crypto++-5.61/CMakeLists.txt
+++ b/external/crypto++-5.61/CMakeLists.txt
@@ -23,10 +23,17 @@ endif()
 if(UNIX AND NOT APPLE)
 	#Downgrade ABI for kisakstrike
 	message(STATUS "Downgrading CXX11 ABI for kisakstrike!")
-	add_definitions(-D_GLIBCXX_USE_CXX11_ABI=0 -O2 -march=native -fpermissive -fpic -Wno-narrowing)
-	# VALVE: when steamclient.so is launched from Python the stack is not 16-byte aligned and gcc assumes
-	# that it will be, causing crashes when writing to SSE local variables.
-	add_definitions( -mstackrealign)
+	if(CMAKE_SYSTEM_PROCESSOR STREQUAL "e2k")
+		# O3 on mcst-lcc approximately equal to O2 at gcc X86/ARM
+		add_definitions(-D_GLIBCXX_USE_CXX11_ABI=0 -O3 -march=native -fpermissive -fpic -Wno-narrowing)
+		# -mstackrealign option is X86 specific and not supported by mcst-lcc
+		# see https://gcc.gnu.org/onlinedocs/gcc/x86-Options.html
+	else()
+		add_definitions(-D_GLIBCXX_USE_CXX11_ABI=0 -O2 -march=native -fpermissive -fpic -Wno-narrowing)
+		# VALVE: when steamclient.so is launched from Python the stack is not 16-byte aligned and gcc assumes
+		# that it will be, causing crashes when writing to SSE local variables.
+		add_definitions( -mstackrealign)
+	endif()
 endif()
 
 set(cryptopp_VERSION_MAJOR 5)

--- a/external/crypto++-5.61/config.h
+++ b/external/crypto++-5.61/config.h
@@ -128,7 +128,7 @@ const lword LWORD_MAX = W64LIT(0xffffffffffffffff);
 	typedef word64 word;
 #else
 	#define CRYPTOPP_NATIVE_DWORD_AVAILABLE
-	#if defined(__alpha__) || defined(__ia64__) || defined(_ARCH_PPC64) || defined(__x86_64__) || defined(__mips64) || defined(__sparc64__)
+	#if defined(__alpha__) || defined(__ia64__) || defined(_ARCH_PPC64) || defined(__x86_64__) || defined(__mips64) || defined(__sparc64__) || defined(__e2k__)
 		#if defined(__GNUC__) && !defined(__INTEL_COMPILER) && !(CRYPTOPP_GCC_VERSION == 40001 && defined(__APPLE__)) && CRYPTOPP_GCC_VERSION >= 30400
 			// GCC 4.0.1 on MacOS X is missing __umodti3 and __udivti3
 			// mode(TI) division broken on amd64 with GCC earlier than GCC 3.4
@@ -165,7 +165,7 @@ NAMESPACE_END
 	#if defined(_M_X64) || defined(__x86_64__)
 		#define CRYPTOPP_L1_CACHE_LINE_SIZE 64
 	#else
-		// L1 cache line size is 32 on Pentium III and earlier
+		// L1 cache line size is 32 on Pentium III and earlier, and on e2k (MCST Elbrus 2000)
 		#define CRYPTOPP_L1_CACHE_LINE_SIZE 32
 	#endif
 #endif
@@ -250,6 +250,12 @@ NAMESPACE_END
 
 #ifndef CRYPTOPP_DISABLE_UNCAUGHT_EXCEPTION
 #define CRYPTOPP_UNCAUGHT_EXCEPTION_AVAILABLE
+#endif
+
+#if defined(__e2k__)
+// disable all x86/x86-64 asm and AES on e2k
+#define CRYPTOPP_DISABLE_ASM
+#define CRYPTOPP_DISABLE_AESNI
 #endif
 
 #ifdef CRYPTOPP_DISABLE_X86ASM		// for backwards compatibility: this macro had both meanings
@@ -341,6 +347,10 @@ NAMESPACE_END
 	#define CRYPTOPP_BOOL_X64 1
 #else
 	#define CRYPTOPP_BOOL_X64 0
+#endif
+
+#if defined(__e2k__)
+	#define CRYPTOPP_BOOL_E2K 1
 #endif
 
 // see http://predef.sourceforge.net/prearch.html

--- a/external/crypto++-5.61/cpu.h
+++ b/external/crypto++-5.61/cpu.h
@@ -178,6 +178,42 @@ inline int GetCacheLineSize()
 	return g_cacheLineSize;
 }
 
+#elif CRYPTOPP_BOOL_E2K
+
+// use compiler definitions to determine e2k CPU features
+
+	#if defined(__MMX__)
+		inline bool HasMMX()	{return true;}
+	#endif
+
+	#if defined(__SSE__)
+		inline bool HasISSE()	{return true;}
+	#endif
+
+	#if defined(__SSE2__)
+		inline bool HasSSE2()	{return true;}
+	#endif
+
+	#if defined(__SSSE3__)
+		inline bool HasSSSE3()	{return true;}
+	#endif
+
+	#if defined(__AES__)
+		inline bool HasAESNI()	{return true;}
+	#endif
+
+	#if defined(__PCLMUL__)
+		inline bool HasCLMUL()	{return true;}
+	#endif
+
+inline bool IsP4()	{return false;}
+
+inline int GetCacheLineSize()
+{
+	// cache1 : level=1 type=Data scope=Private size=64K line_size=32 associativity=4
+	return 32;
+}
+
 #else
 
 inline int GetCacheLineSize()


### PR DESCRIPTION
Added e2k support in Crypto++ 5.61.