### PR TITLE
Animations: fix ACT_CSGO_IDLE_TURN_BALANCEADJUST

### DIFF
--- a/game/shared/cstrike15/csgo_playeranimstate.cpp
+++ b/game/shared/cstrike15/csgo_playeranimstate.cpp
@@ -1,4 +1,4 @@
- //========= Copyright © 1996-2005, Valve Corporation, All rights reserved. ============//
+ //========= Copyright ï¿½ 1996-2005, Valve Corporation, All rights reserved. ============//
 //
 // Purpose: 
 //
@@ -2377,7 +2377,7 @@ void CCSGOPlayerAnimState::SetUpVelocity( void )
 	}
 
 #ifndef CLIENT_DLL
-	if ( m_flVelocityLengthXY <= CS_PLAYER_SPEED_STOPPED && m_bOnGround && !m_bOnLadder && !m_bLanding && m_flLastUpdateIncrement > 0 && abs( AngleDiff( m_flFootYawLast, m_flFootYaw ) / m_flLastUpdateIncrement > CSGO_ANIM_READJUST_THRESHOLD ) )
+	if ( m_flVelocityLengthXY <= CS_PLAYER_SPEED_STOPPED && m_bOnGround && !m_bOnLadder && !m_bLanding && m_flLastUpdateIncrement > 0 && abs( AngleDiff( m_flFootYawLast, m_flFootYaw ) / m_flLastUpdateIncrement ) > CSGO_ANIM_READJUST_THRESHOLD )
 	{
 		SetLayerSequence( ANIMATION_LAYER_ADJUST, SelectSequenceFromActMods( ACT_CSGO_IDLE_TURN_BALANCEADJUST ) );
 		m_bAdjustStarted = true;


### PR DESCRIPTION
The way valve placed the braces here doesn't make sense, it is equivalent to
```cpp
float d = AngleDiff( m_flFootYawLast, m_flFootYaw );
float scaled = d / m_flLastUpdateIncrement;
bool bigger = scaled > CSGO_ANIM_READJUST_THRESHOLD;
if(abs( bigger ))
```
It obviously doesn't make sense to call abs() on a bool, this causes the "shaky animation" only to be toggled when turning to the left.
furthermore, valve fixed this themselves somewhere around ~2020
![image](https://user-images.githubusercontent.com/49956509/169453319-13c1e0ec-370a-4c98-a265-ecae75b7a121.png)
